### PR TITLE
lyraphase.opnsense: Switch stock GHA to use on: pull_request

### DIFF
--- a/collections/ansible_collections/lyraphase/opnsense/.github/workflows/check_label.yml
+++ b/collections/ansible_collections/lyraphase/opnsense/.github/workflows/check_label.yml
@@ -4,7 +4,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 on: # yamllint disable-line rule:truthy
-  pull_request_target:
+  # Use pull_request rather than pull_request_target to avoid exposing secrets
+  # other than the ReadOnly GITHUB_TOKEN
+  pull_request:
     types: [opened, labeled, unlabeled, synchronize]
 jobs:
   check_label:


### PR DESCRIPTION
Change the default GHA trigger away from using the insecure pull_request_target

Change-Id: Ice837bc9f101a7e5c3309ace8a646c4a508f4568
